### PR TITLE
Increase label's minimal width to avoid slider jitter

### DIFF
--- a/src/components/audio/volume.rs
+++ b/src/components/audio/volume.rs
@@ -60,6 +60,7 @@ impl SimpleComponent for VolumeModel {
                 add_suffix = &gtk::Label {
                     #[watch]
                     set_label: &format!("{}%", model.volume as i32),
+                    set_width_chars: 5,
                 },
             },
         }

--- a/src/components/display/oled_dimming.rs
+++ b/src/components/display/oled_dimming.rs
@@ -92,7 +92,7 @@ impl Component for OledDimmingModel {
                 add_suffix = &gtk::Label {
                     #[watch]
                     set_label: &format!("{}%", model.brightness),
-                    set_width_chars: 4,
+                    set_width_chars: 5,
                     set_xalign: 1.0,
                 },
             },


### PR DESCRIPTION
When the volume is modified by dragging the slider, the text length changes will change slider position, which can cause slider jitter and value fluctuation in certain positions (e.g. somewhere near 51%).

This PR solves the issue by increasing the minimal width of labels, preventing slider position from shifting.

Slider position in the display panel will change as well when dimming level is increased to 100%, although it will never jitter due to different value range. The label's minimal width is increased for aesthetic reasons.