### PR TITLE
fix(appimage): Fix the icon not appearing with AppImage in GNOME

### DIFF
--- a/packaging/asus-hub-appimage.desktop
+++ b/packaging/asus-hub-appimage.desktop
@@ -7,4 +7,5 @@ Exec=asus-hub
 Icon=asus-hub
 Terminal=false
 StartupNotify=true
+StartupWMClass=de.guido.asus-hub
 Categories=Settings;HardwareSettings;System;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ fn main() {
     let start_hidden = args.iter().any(|arg| arg == "--hidden");
     let gtk_args: Vec<String> = args.into_iter().filter(|arg| arg != "--hidden").collect();
 
+    gtk4::glib::set_prgname(Some("de.guido.asus-hub"));
     let a = relm4::RelmApp::new("de.guido.asus-hub").with_args(gtk_args);
     load_css();
     relm4::adw::StyleManager::default().set_color_scheme(relm4::adw::ColorScheme::PreferDark);


### PR DESCRIPTION
This fix the icon of AppImage that not appear in GNOME.

Running via command line without use of GearLevel or something like that...

Dock
<img width="100" height="86" alt="image" src="https://github.com/user-attachments/assets/d4a67d16-1edb-4483-b4fd-bd828b4184cb" />

Overview
<img width="342" height="261" alt="image" src="https://github.com/user-attachments/assets/fccf75aa-30dc-4099-926c-f1285150e6d4" />
