### PR TITLE
Add NixOS support via flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ Add `ayuz` to your `flake.nix` inputs: `ayuz.url = "github:Klbgr/Ayuz";`.
   { inputs, ... }: {
     imports = [ inputs.ayuz.nixosModules.default ];
     services.ayuz.enable = true;
-    services.ayuz.supportMyAsusKey = true; # Optional: Rebind MyAsus/ROG key to launch Ayuz
+    services.ayuz.supportMyAsusKey = true; # Rebind MyAsus/ROG key to launch Ayuz
+    services.ayuz.fnKeyMode = "shortcut"; # Set the initial Fn key lock state
   }
   ```
 - **Home Manager Module:** For per-user installation, optional autostart, and configuration.
@@ -257,12 +258,10 @@ Add `ayuz` to your `flake.nix` inputs: `ayuz.url = "github:Klbgr/Ayuz";`.
     ayuz-flake = builtins.getFlake "github:Klbgr/Ayuz";
   in {
     imports = [ ayuz-flake.nixosModules.default ];
-    services.ayuz.enable = true;
-    services.ayuz.supportMyAsusKey = true;
+    services.ayuz = { ... };
     home-manager.users.username = {
       imports = [ ayuz-flake.homeManagerModules.default ];
-      programs.ayuz.enable = true;
-      programs.ayuz.autostart = true;
+      programs.ayuz = { ... };
     };
   }
   ```

--- a/README.md
+++ b/README.md
@@ -238,12 +238,16 @@ Add `ayuz` to your `flake.nix` inputs: `ayuz.url = "github:Klbgr/Ayuz";`.
     services.ayuz.supportMyAsusKey = true; # Optional: Rebind MyAsus/ROG key to launch Ayuz
   }
   ```
-- **Home Manager Module:** For per-user installation and optional autostart.
+- **Home Manager Module:** For per-user installation, optional autostart, and configuration.
   ```nix
   { inputs, ... }: {
     imports = [ inputs.ayuz.homeManagerModules.default ];
     programs.ayuz.enable = true;
     programs.ayuz.autostart = true; # Start minimized on login
+    programs.ayuz.settings = {
+      # accepts either a Nix attribute set or a raw JSON string
+      language = "en";
+    };
   }
   ```
 - **Traditional (Flakeless) usage:** You can use `builtins.getFlake` to use the modules or package directly.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ sudo dnf install gtk4-devel libadwaita-devel
 sudo pacman -S gtk4 libadwaita
 ```
 
+**NixOs**
+
+```bash
+nix develop
+```
+
 ### 2. Install external tools
 
 Most tools are already included with a standard Fedora KDE installation (`kscreen-doctor`, `kwriteconfig6`, `wpctl`). The following need to be installed manually: <br>
@@ -225,6 +231,43 @@ sudo dnf copr enable skyr0ver/asus-hub
 sudo dnf install asus-hub
 sudo systemctl enable --now supergfxd.service
 ```
+
+**NixOS (Flakes):**
+
+Add `ayuz` to your `flake.nix` inputs: `ayuz.url = "github:Klbgr/Ayuz";`.
+
+- **NixOS Module (Recommended):** Automatically configures required system services (`asusd`, `supergfxd`), udev rules, and polkit policies.
+  ```nix
+  { inputs, ... }: {
+    imports = [ inputs.ayuz.nixosModules.default ];
+    services.ayuz.enable = true;
+    services.ayuz.supportMyAsusKey = true; # Optional: Rebind MyAsus/ROG key to launch Ayuz
+  }
+  ```
+- **Home Manager Module:** For per-user installation and optional autostart.
+  ```nix
+  { inputs, ... }: {
+    imports = [ inputs.ayuz.homeManagerModules.default ];
+    programs.ayuz.enable = true;
+    programs.ayuz.autostart = true; # Start minimized on login
+  }
+  ```
+- **Traditional (Flakeless) usage:** You can use `builtins.getFlake` to use the modules or package directly.
+  ```nix
+  { pkgs, ... }: 
+  let
+    ayuz-flake = builtins.getFlake "github:Klbgr/Ayuz";
+  in {
+    imports = [ ayuz-flake.nixosModules.default ];
+    services.ayuz.enable = true;
+    services.ayuz.supportMyAsusKey = true;
+    home-manager.users.username = {
+      imports = [ ayuz-flake.homeManagerModules.default ];
+      programs.ayuz.enable = true;
+      programs.ayuz.autostart = true;
+    };
+  }
+  ```
 
 **Manual Download:**
 

--- a/README.md
+++ b/README.md
@@ -177,12 +177,6 @@ sudo dnf install gtk4-devel libadwaita-devel
 sudo pacman -S gtk4 libadwaita
 ```
 
-**NixOs**
-
-```bash
-nix develop
-```
-
 ### 2. Install external tools
 
 Most tools are already included with a standard Fedora KDE installation (`kscreen-doctor`, `kwriteconfig6`, `wpctl`). The following need to be installed manually: <br>

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,6 @@
                     wireplumber
                     easyeffects
                     procps
-                    polkit
                     coreutils
                     which
                     xdg-utils

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,198 @@
+{
+  description = "The unofficial MyAsus alternative for Linux";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.ayuz = pkgs.rustPlatform.buildRustPackage {
+          pname = "ayuz";
+          version = "1.0.7-unstable-${pkgs.lib.substring 0 8 (self.lastModifiedDate or "00000000")}";
+
+          src = pkgs.lib.cleanSource ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            wrapGAppsHook4
+            gettext
+          ];
+
+          buildInputs = with pkgs; [
+            gtk4
+            libadwaita
+            dbus
+          ];
+
+          preFixup = ''
+            gappsWrapperArgs+=(
+              --prefix PATH : ${
+                pkgs.lib.makeBinPath (
+                  with pkgs;
+                  [
+                    asusctl
+                    kdePackages.qttools
+                    kdePackages.libkscreen
+                    kdePackages.kconfig
+                    swayidle
+                    wireplumber
+                    easyeffects
+                    procps
+                    polkit
+                    coreutils
+                    which
+                    xdg-utils
+                    brightnessctl
+                    playerctl
+                    pulseaudio
+                  ]
+                )
+              }
+            )
+          '';
+
+          postInstall = ''
+            install -Dm644 packaging/de.guido.ayuz.desktop -t $out/share/applications/
+            install -Dm644 packaging/de.guido.ayuz.metainfo.xml -t $out/share/metainfo/
+            install -Dm644 assets/trayicon.png $out/share/icons/hicolor/128x128/apps/de.guido.ayuz.png
+          '';
+
+          meta = with pkgs.lib; {
+            description = "The unofficial MyAsus alternative for Linux";
+            homepage = "https://github.com/Traciges/Ayuz";
+            license = licenses.gpl3Plus;
+            platforms = platforms.linux;
+            mainProgram = "ayuz";
+          };
+        };
+
+        packages.default = self.packages.${system}.ayuz;
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${system}.ayuz ];
+          nativeBuildInputs = with pkgs; [
+            rustc
+            cargo
+            rust-analyzer
+            clippy
+            rustfmt
+          ];
+
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (
+            with pkgs;
+            [
+              gtk4
+              libadwaita
+              dbus
+            ]
+          );
+        };
+      }
+    )
+    // {
+      nixosModules.default =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.services.ayuz;
+          ayuz-pkg = self.packages.${pkgs.system}.default;
+        in
+        {
+          options.services.ayuz = {
+            enable = lib.mkEnableOption "Ayuz - The unofficial MyAsus alternative for Linux";
+            supportMyAsusKey = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Whether to rebind the MyAsus/ROG key to launch Ayuz.";
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            environment.systemPackages = [ ayuz-pkg ];
+
+            services.asusd.enable = lib.mkDefault true;
+            # Force asusd to start on boot
+            systemd.services.asusd.wantedBy = [ "multi-user.target" ];
+            services.supergfxd.enable = lib.mkDefault true;
+            hardware.sensor.iio.enable = lib.mkDefault true;
+            security.polkit.enable = lib.mkDefault true;
+            services.playerctld.enable = lib.mkDefault true;
+
+            services.triggerhappy = lib.mkIf cfg.supportMyAsusKey {
+              enable = true;
+              user = "root";
+              bindings = [
+                {
+                  keys = [ "PROG1" ];
+                  event = "press";
+                  cmd = "${pkgs.bash}/bin/bash -c '${pkgs.systemd}/bin/systemd-run --user --machine=$(${pkgs.systemd}/bin/loginctl list-users --no-legend | ${pkgs.coreutils}/bin/head -n1 | ${pkgs.gawk}/bin/awk \"{print \\$2}\")@.host ${ayuz-pkg}/bin/ayuz'";
+                }
+              ];
+            };
+
+            services.udev.extraRules = ''
+              ACTION=="add|change", KERNEL=="event*", ATTRS{name}=="*Touchpad*", MODE="0660", GROUP="input"
+            '';
+          };
+        };
+
+      homeManagerModules.default =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.programs.ayuz;
+          ayuz-pkg = self.packages.${pkgs.system}.default;
+        in
+        {
+          options.programs.ayuz = {
+            enable = lib.mkEnableOption "Ayuz";
+            autostart = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Start Ayuz minimized on login.";
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            home.packages = [ ayuz-pkg ];
+
+            systemd.user.services.ayuz = lib.mkIf cfg.autostart {
+              Unit = {
+                Description = "Ayuz - The unofficial MyAsus alternative for Linux";
+                After = [ "graphical-session.target" ];
+                PartOf = [ "graphical-session.target" ];
+              };
+              Service = {
+                ExecStart = "${ayuz-pkg}/bin/ayuz --hidden";
+                Restart = "always";
+              };
+              Install.WantedBy = [ "graphical-session.target" ];
+            };
+          };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -177,10 +177,37 @@
               default = false;
               description = "Start Ayuz minimized on login.";
             };
+            settings = lib.mkOption {
+              type =
+                with lib.types;
+                nullOr (
+                  either str (submodule {
+                    freeformType = (pkgs.formats.json { }).type;
+                  })
+                );
+              default = null;
+              description = ''
+                Configuration written to <filename>~/.config/ayuz/config.json</filename>.
+                Accepts either a Nix attribute set or a raw JSON string.
+                See the application for available options.
+                If set to <literal>null</literal> (default), the configuration is not managed by Nix.
+              '';
+            };
           };
 
           config = lib.mkIf cfg.enable {
             home.packages = [ ayuz-pkg ];
+
+            xdg.configFile."ayuz/config.json" = lib.mkIf (cfg.settings != null) (
+              if lib.isString cfg.settings then
+                {
+                  text = cfg.settings;
+                }
+              else
+                {
+                  source = (pkgs.formats.json { }).generate "ayuz-config" cfg.settings;
+                }
+            );
 
             systemd.user.services.ayuz = lib.mkIf cfg.autostart {
               Unit = {

--- a/flake.nix
+++ b/flake.nix
@@ -126,10 +126,16 @@
               default = true;
               description = "Whether to rebind the MyAsus/ROG key to launch Ayuz.";
             };
+            fnKeyMode = lib.mkOption {
+              type = lib.types.nullOr (lib.types.enum [ "function" "shortcut" ]);
+              default = "shortcut";
+              description = "Priority for the top row of keys: 'function' for F1-F12, 'shortcut' for media keys (volume, brightness, etc.). Sets asus_wmi.fnlock_default.";
+            };
           };
 
           config = lib.mkIf cfg.enable {
             environment.systemPackages = [ ayuz-pkg ];
+            boot.kernelParams = lib.optional (cfg.fnKeyMode != null) "asus_wmi.fnlock_default=${if cfg.fnKeyMode == "function" then "1" else "0"}";
 
             services.asusd.enable = lib.mkDefault true;
             # Force asusd to start on boot

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
       {
         packages.ayuz = pkgs.rustPlatform.buildRustPackage {
           pname = "ayuz";
-          version = "1.0.7-unstable-${pkgs.lib.substring 0 8 (self.lastModifiedDate or "00000000")}";
+          version = "1.0.8-unstable-${pkgs.lib.substring 0 8 (self.lastModifiedDate or "00000000")}";
 
           src = pkgs.lib.cleanSource ./.;
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,8 @@
                     brightnessctl
                     playerctl
                     pulseaudio
+                    iio-sensor-proxy
+                    glib
                   ]
                 )
               }


### PR DESCRIPTION
Adding a flake to install Ayuz from source and configure it declaratively on NixOS with the correct dependencies.
Also adds NixOS and Home Manager modules.
Optionally remaps the MyAsus key to open Ayuz.

Tested on Asus Zenbook 14 UX434FL running NixOS 25.11 with KDE: 
- did not test "GPU Memory Allocation" and "Automatic Keyboard Backlight" as those are not supported on this laptop
- ~pkexec based features don't work~
  - fixed by commits db473e3c932a7011e97140769c4332a77c426932 and 6089e5c71d5d4cf233f4a55cb6702899573a4efd
- everything else works
- MyAsus key remapping works on my own laptop
  - but not sure if it will work on other Zenbook or even ROG laptops
  - might not work as expected when multiple users are logged

This is my first flake (built with some AI assistance) and I have little to no experience with Rust, so feedback and improvements from the community are very welcome!

**Should not be merged until above issues are resolved.**